### PR TITLE
JIT Perf. Issue

### DIFF
--- a/word_language_model/main.py
+++ b/word_language_model/main.py
@@ -12,7 +12,7 @@ parser = argparse.ArgumentParser(description='PyTorch PennTreeBank RNN/LSTM Lang
 parser.add_argument('--data', type=str, default='./data/penn',
                     help='location of the data corpus')
 parser.add_argument('--model', type=str, default='LSTM',
-                    help='type of recurrent net (RNN_TANH, RNN_RELU, LSTM, GRU)')
+                    help='type of recurrent net (LSTM)')
 parser.add_argument('--emsize', type=int, default=200,
                     help='size of word embeddings')
 parser.add_argument('--nhid', type=int, default=200,
@@ -133,6 +133,7 @@ def train():
         model.zero_grad()
         output, hidden = model(data, hidden)
         loss = criterion(output.view(-1, ntokens), targets)
+        loss = loss + 0*(hidden[0].sum() + hidden[1].sum())
         loss.backward()
 
         # `clip_grad_norm` helps prevent the exploding gradient problem in RNNs / LSTMs.


### PR DESCRIPTION
When I run `word_language_model` with `python main.py  --cuda --nlayers 1` I am getting:

```
 | epoch   1 |   400/ 1327 batches | lr 20.00 | ms/batch 25.91 | loss  6.07 | ppl   431.54
```

While when I run it with the CuDNN RNN I get:

```
| epoch   1 |   400/ 1327 batches | lr 20.00 | ms/batch  9.39 | loss  6.06 | ppl   429.87
```

This is more than 2x faster. Without JIT enabled, I get:

```
| epoch   1 |   400/ 1327 batches | lr 20.00 | ms/batch 31.51 | loss  6.07 | ppl   431.49
```

So JIT is faster but not by much. I remember us having better results a few weeks ago on essentially the same problem. What is going on?
